### PR TITLE
fix: add the ability to specify the version

### DIFF
--- a/pkg/generator/gcpsecrets.go
+++ b/pkg/generator/gcpsecrets.go
@@ -52,7 +52,7 @@ func (imp *GcpSecrets) getTokenValue(v *retrieveStrategy) (string, error) {
 		version = imp.config.Version
 	}
 
-	log.Infof("Getting Secret: %s @version: ", imp.token, version)
+	log.Infof("Getting Secret: %s @version: %s", imp.token, version)
 
 	input := &gcpsecretspb.AccessSecretVersionRequest{
 		Name: fmt.Sprintf("%s/versions/%s", v.stripPrefix(imp.token, GcpSecretsPrefix), version),

--- a/pkg/generator/gcpsecrets.go
+++ b/pkg/generator/gcpsecrets.go
@@ -15,10 +15,11 @@ type gcpSecretsApi interface {
 }
 
 type GcpSecrets struct {
-	svc   gcpSecretsApi
-	ctx   context.Context
-	close func() error
-	token string
+	svc    gcpSecretsApi
+	ctx    context.Context
+	config TokenConfigVars
+	close  func() error
+	token  string
 }
 
 func NewGcpSecrets(ctx context.Context) (*GcpSecrets, error) {
@@ -37,18 +38,26 @@ func NewGcpSecrets(ctx context.Context) (*GcpSecrets, error) {
 }
 
 func (imp *GcpSecrets) setToken(token string) {
-	imp.token = token
+	ct := (GenVarsConfig{}).ParseTokenVars(token)
+	imp.config = ct
+	imp.token = ct.Token
 }
 
 func (imp *GcpSecrets) getTokenValue(v *retrieveStrategy) (string, error) {
 	defer imp.close()
-
 	log.Infof("%s", "Concrete implementation GcpSecrets")
-	log.Infof("Getting Secret: %s", imp.token)
+
+	version := "latest"
+	if imp.config.Version != "" {
+		version = imp.config.Version
+	}
+
+	log.Infof("Getting Secret: %s @version: ", imp.token, version)
 
 	input := &gcpsecretspb.AccessSecretVersionRequest{
-		Name: fmt.Sprintf("%s/versions/latest", v.stripPrefix(imp.token, GcpSecretsPrefix)),
+		Name: fmt.Sprintf("%s/versions/%s", v.stripPrefix(imp.token, GcpSecretsPrefix), version),
 	}
+
 	ctx, cancel := context.WithCancel(imp.ctx)
 	defer cancel()
 

--- a/pkg/generator/gcpsecrets_test.go
+++ b/pkg/generator/gcpsecrets_test.go
@@ -79,6 +79,16 @@ func Test_GetGcpSecretVarHappy(t *testing.T) {
 			})
 		}, NewConfig().WithTokenSeparator("#").WithKeySeparator("|"),
 		},
+		"success with version": {"GCPSECRETS#/token/1[version:123]", "someValue", func(t *testing.T) gcpSecretsApi {
+			return mockGcpSecretsApi(func(ctx context.Context, req *gcpsecretspb.AccessSecretVersionRequest, opts ...gax.CallOption) (*gcpsecretspb.AccessSecretVersionResponse, error) {
+				t.Helper()
+				gcpSecretsGetChecker(t, req)
+				return &gcpsecretspb.AccessSecretVersionResponse{
+					Payload: &gcpsecretspb.SecretPayload{Data: []byte("someValue")},
+				}, nil
+			})
+		}, NewConfig().WithTokenSeparator("#").WithKeySeparator("|"),
+		},
 		"error": {"GCPSECRETS#/token/1", "unable to retrieve secret", func(t *testing.T) gcpSecretsApi {
 			return mockGcpSecretsApi(func(ctx context.Context, req *gcpsecretspb.AccessSecretVersionRequest, opts ...gax.CallOption) (*gcpsecretspb.AccessSecretVersionResponse, error) {
 				t.Helper()

--- a/pkg/generator/keyvault.go
+++ b/pkg/generator/keyvault.go
@@ -75,7 +75,8 @@ func (imp *KvScrtStore) getTokenValue(v *retrieveStrategy) (string, error) {
 	defer cancel()
 
 	// secretVersion as "" => latest
-	s, err := imp.svc.GetSecret(ctx, imp.token, "", nil)
+	// imp.config.Version will default `""` if not specified
+	s, err := imp.svc.GetSecret(ctx, imp.token, imp.config.Version, nil)
 	if err != nil {
 		log.Errorf(implementationNetworkErr, AzKeyVaultSecretsPrefix, err, imp.token)
 		return "", err

--- a/pkg/generator/keyvault_test.go
+++ b/pkg/generator/keyvault_test.go
@@ -89,7 +89,7 @@ func (m mockAzKvSecretApi) GetSecret(ctx context.Context, name string, version s
 	return m(ctx, name, version, options)
 }
 
-func Test_GetAzKeyVaultSecretVarHappy(t *testing.T) {
+func TestAzKeyVault(t *testing.T) {
 
 	tests := map[string]struct {
 		token      string
@@ -98,6 +98,16 @@ func Test_GetAzKeyVaultSecretVarHappy(t *testing.T) {
 		config     *GenVarsConfig
 	}{
 		"successVal": {"AZKVSECRET#/test-vault//token/1", tsuccessParam, func(t *testing.T) kvApi {
+			return mockAzKvSecretApi(func(ctx context.Context, name string, version string, options *azsecrets.GetSecretOptions) (azsecrets.GetSecretResponse, error) {
+				t.Helper()
+				azKvCommonGetSecretChecker(t, name, "", "/token/1")
+				resp := azsecrets.GetSecretResponse{}
+				resp.Value = &tsuccessParam
+				return resp, nil
+			})
+		}, NewConfig().WithKeySeparator("|").WithTokenSeparator("#"),
+		},
+		"successVal with version": {"AZKVSECRET#/test-vault//token/1[version:123]", tsuccessParam, func(t *testing.T) kvApi {
 			return mockAzKvSecretApi(func(ctx context.Context, name string, version string, options *azsecrets.GetSecretOptions) (azsecrets.GetSecretResponse, error) {
 				t.Helper()
 				azKvCommonGetSecretChecker(t, name, "", "/token/1")

--- a/pkg/generator/paramstore.go
+++ b/pkg/generator/paramstore.go
@@ -14,9 +14,10 @@ type paramStoreApi interface {
 }
 
 type ParamStore struct {
-	svc   paramStoreApi
-	ctx   context.Context
-	token string
+	svc    paramStoreApi
+	ctx    context.Context
+	config TokenConfigVars
+	token  string
 }
 
 func NewParamStore(ctx context.Context) (*ParamStore, error) {
@@ -34,7 +35,9 @@ func NewParamStore(ctx context.Context) (*ParamStore, error) {
 }
 
 func (imp *ParamStore) setToken(token string) {
-	imp.token = token
+	ct := (GenVarsConfig{}).ParseTokenVars(token)
+	imp.config = ct
+	imp.token = ct.Token
 }
 
 func (imp *ParamStore) getTokenValue(v *retrieveStrategy) (string, error) {

--- a/pkg/generator/secretsmanager_test.go
+++ b/pkg/generator/secretsmanager_test.go
@@ -85,7 +85,7 @@ func Test_GetSecretMgr(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			tt.config.WithTokenSeparator(tt.tokenSeparator).WithKeySeparator(tt.keySeparator)
-			impl, _ := NewSecretsMgr(context.TODO(), *tt.config)
+			impl, _ := NewSecretsMgr(context.TODO())
 			impl.svc = tt.mockClient(t)
 			rs := newRetrieveStrategy(NewDefatultStrategy(), *tt.config)
 

--- a/pkg/generator/secretsmanager_test.go
+++ b/pkg/generator/secretsmanager_test.go
@@ -53,6 +53,16 @@ func Test_GetSecretMgr(t *testing.T) {
 			})
 		}, NewConfig(),
 		},
+		"success with version": {"AWSSECRETS#/token/1[version:123]", "|", "#", tsuccessParam, func(t *testing.T) secretsMgrApi {
+			return mockSecretsApi(func(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+				t.Helper()
+				awsSecretsMgrGetChecker(t, params)
+				return &secretsmanager.GetSecretValueOutput{
+					SecretString: &tsuccessSecret,
+				}, nil
+			})
+		}, NewConfig(),
+		},
 		"success with binary": {"AWSSECRETS#/token/1", "|", "#", tsuccessParam, func(t *testing.T) secretsMgrApi {
 			return mockSecretsApi(func(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
 				t.Helper()

--- a/pkg/generator/strategy.go
+++ b/pkg/generator/strategy.go
@@ -56,7 +56,7 @@ func (rs *retrieveStrategy) RetrieveByToken(ctx context.Context, impl genVarsStr
 func (rs *retrieveStrategy) SelectImplementation(ctx context.Context, prefix ImplementationPrefix, in string, config GenVarsConfig) (genVarsStrategy, error) {
 	switch prefix {
 	case SecretMgrPrefix:
-		return NewSecretsMgr(ctx, config)
+		return NewSecretsMgr(ctx)
 	case ParamStorePrefix:
 		return NewParamStore(ctx)
 	case AzKeyVaultSecretsPrefix:

--- a/pkg/generator/strategy_test.go
+++ b/pkg/generator/strategy_test.go
@@ -100,7 +100,7 @@ func TestSelectImpl(t *testing.T) {
 			context.TODO(),
 			SecretMgrPrefix, "AWSSECRETS://foo/bar", (&GenVarsConfig{}).WithKeySeparator("|").WithTokenSeparator("://"),
 			func(t *testing.T, ctx context.Context, conf GenVarsConfig) genVarsStrategy {
-				imp, err := NewSecretsMgr(ctx, conf)
+				imp, err := NewSecretsMgr(ctx)
 				if err != nil {
 					t.Errorf(testutils.TestPhraseWithContext, "aws secrets init impl error", err.Error(), nil)
 				}


### PR DESCRIPTION
use implementation's own version designation e.g. `1` in VAULT or `latest` in GCPSECRETS

+semver: feature

closes #18 